### PR TITLE
README tweaks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,10 @@ MISO, MOSI and SSEL pin definitions are target-specific. To function correctly, 
 
 1. First, find the pin references in the source files.  In this example, view ``spi_asynch.cpp``. The pin references are ``YOTTA_CFG_HARDWARE_TEST_PINS_SPI_MISO``, ``YOTTA_CFG_HARDWARE_TEST_PINS_SPI_MOSI`` and ``YOTTA_CFG_HARDWARE_TEST_PINS_SPI_SSEL``.
 
-2. Next, find the target-specific pin definitions corresponding to the pin references in the target's ``target.json`` file. The file is located at ``yotta_targets/frdm-k64f-gcc/target.json``.
+2. Next, find these target-specific pin references in the configuration data by running the command:
+ ```
+ yotta config
+ ```
 
     Each keyword in the pin reference represents a level in the target configuration structure.  To find what YOTTA_CFG_HARDWARE_TEST_PINS_SPI resolves to, look under config/hardware/test-pins/spi.
 
@@ -38,32 +41,33 @@ MISO, MOSI and SSEL pin definitions are target-specific. To function correctly, 
     }
     ```
 
-3. Finally, locate those pins on the board's [pinout picture](http://developer.mbed.org/platforms/FRDM-K64F/#overview).
+3. Finally, locate those pins on the board's [pinout picture](https://www.mbed.com/en/development/hardware/boards/nxp/frdm_k64f/#overview).
 
 ### Getting started
 
 1. Connect the FRDM-K64F to the computer with the micro-USB cable, being careful to use the micro-USB port labeled "OpenSDA".
 
-3. Assuming you have cloned this repository or receive it with a release tarball, open a terminal window and navigate to the repository's folder.
+2. Assuming you have cloned this repository or receive it with a release tarball, open a terminal window and navigate to the repository's folder.
 
     ```
     cd /path/to/example-asynch-spi
     ```
 
-4. Select the yotta target and build to it:
+3. Select the yotta target and build to it:
 
     ```
     yotta target frdm-k64f-gcc
     yotta build
     ```
+4. Connect YOTTA_CFG_HARDWARE_TEST_PINS_SPI_MOSI to YOTTA_CFG_HARDWARE_TEST_PINS_SPI_MISO with a cable. See the previous section for an explanation if you do not know how to locate these.
 
-3. Copy ``build/frdm-k64f-gcc/source/example-asynch-spi.bin`` to your mbed board and wait until the LED next to the USB port stops blinking.
+5. Copy ``build/frdm-k64f-gcc/source/example-asynch-spi.bin`` to your mbed board and wait until the LED next to the USB port stops blinking.
 
-4. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control.
+6. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control.
 
-5. Press the reset button on the board.
+7. Press the reset button on the board.
 
-6. The output in the terminal should look like this:
+8. The output in the terminal should look like this:
 
     ```
     Starting short transfer test


### PR DESCRIPTION
- Instruct the user to use the yotta config command instead of looking in the target's target.json file for the pin definitions.
- Change the link to the K64F's pinout diagram from mbed.org to mbed.com
- Fix the numbering in the README lists (I know it doesn't mater once GitHub renders the markdown, but I like fixing it for offline reading too :) )